### PR TITLE
Display the server error message to the user

### DIFF
--- a/lib/metal_client/cli.rb
+++ b/lib/metal_client/cli.rb
@@ -34,7 +34,7 @@ require 'metal_client/errors'
 
 module MetalClient
   # TODO: Move me to a new file
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 
   class CLI
     extend Commander::Delegates

--- a/lib/metal_client/cli.rb
+++ b/lib/metal_client/cli.rb
@@ -520,7 +520,7 @@ module MetalClient
       c.option '--[no-]member', <<~OPT
         Explicitly set if the request is sent to the member route (/<type>/<id>).
         Using --no-member flag will send the request to the collection route
-        (/<type>). By default all POST or requests with an ID are sent to the members
+        (/<type>). By default all non-POST requests with an ID are sent to the members
         route.
       OPT
       c.option '--[no-]body', <<~OPT

--- a/lib/metal_client/cli.rb
+++ b/lib/metal_client/cli.rb
@@ -75,14 +75,11 @@ module MetalClient
                             else
                               nil
                             end
-          msg = if new_error_class && e.env.response_headers['content-type'] == 'application/vnd.api+json'
-                  e.env.body['errors'].map { |e| e['detail'] }.join("\n\n")
-                end
-          if new_error_class && msg
+          if new_error_class && e.env.response_headers['content-type'] == 'application/vnd.api+json'
             raise new_error_class, <<~MESSAGE.chomp
               #{e.message}
 
-              #{msg}
+              #{e.env.body['errors'].map do |e| e['detail'] end.join("\n\n")}
             MESSAGE
           else
             raise e


### PR DESCRIPTION
The server generates multiple different error messages particularly when a service as failed to validate or restart. As such, these errors should be displayed to the user